### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@ SecretSwitch
 ============
 Protect your secret info while switching apps.
 
-##Demo
+## Demo
 
 Like this:
 
 ![demo](https://raw2.github.com/croath/SecretSwitch/master/demo.gif)
 
-##How to
+## How to
 
     #import "SerectSwitch.h"
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
